### PR TITLE
Add basic MCP server with HTCondor job endpoints

### DIFF
--- a/htcondor_mcp/condor_utils.py
+++ b/htcondor_mcp/condor_utils.py
@@ -1,0 +1,39 @@
+import json
+import htcondor
+
+
+def _serialize(value):
+    """Ensure value is JSON serializable."""
+    try:
+        json.dumps(value)
+        return value
+    except TypeError:
+        return str(value)
+
+
+def list_jobs():
+    """Return a list of current jobs with select attributes."""
+    attrs = [
+        "ClusterId",
+        "Owner",
+        "JobStatus",
+        "Cmd",
+        "RequestCpus",
+        "RequestMemory",
+    ]
+    schedd = htcondor.Schedd()
+    ads = schedd.query(projection=attrs)
+    results = []
+    for ad in ads:
+        results.append({attr: _serialize(ad.get(attr)) for attr in attrs})
+    return results
+
+
+def get_job(job_id):
+    """Return full info for the job with the given ClusterId."""
+    schedd = htcondor.Schedd()
+    ads = schedd.query(f"ClusterId == {int(job_id)}")
+    if not ads:
+        return None
+    ad = ads[0]
+    return {k: _serialize(v) for k, v in ad.items()}

--- a/htcondor_mcp/requirements.txt
+++ b/htcondor_mcp/requirements.txt
@@ -1,0 +1,3 @@
+flask
+jsonrpcserver
+htcondor

--- a/htcondor_mcp/server.py
+++ b/htcondor_mcp/server.py
@@ -1,0 +1,29 @@
+from flask import Flask, request, jsonify
+from jsonrpcserver import method, dispatch
+
+from . import condor_utils
+
+app = Flask(__name__)
+
+
+@method
+def list_jobs():
+    return condor_utils.list_jobs()
+
+
+@method
+def get_job(job_id: int):
+    job = condor_utils.get_job(job_id)
+    if job is None:
+        return {"error": f"Job {job_id} not found"}
+    return job
+
+
+@app.route("/", methods=["POST"])
+def index():
+    response = dispatch(request.get_data().decode())
+    return jsonify(response), response.http_status
+
+
+if __name__ == "__main__":
+    app.run(host="localhost", port=8000)


### PR DESCRIPTION
## Summary
- add `htcondor_mcp` package
- implement Flask JSON-RPC server exposing `list_jobs` and `get_job`
- add helper utilities for querying HTCondor
- include basic requirements file

## Testing
- `python -m py_compile htcondor_mcp/condor_utils.py htcondor_mcp/server.py`


------
https://chatgpt.com/codex/tasks/task_e_686bea8061a083248d97c4200968e4bf